### PR TITLE
runContainer.shの実行結果を追加

### DIFF
--- a/logs/shell-log.txt
+++ b/logs/shell-log.txt
@@ -1,0 +1,5 @@
+~/Desktop/java-design-pattern [master] $ ./runContainer.sh
+6b2f81f18d5d
+6b2f81f18d5d
+delete container
+root@897bd347d0cd:/#

--- a/logs/shell-log.txt
+++ b/logs/shell-log.txt
@@ -1,5 +1,0 @@
-~/Desktop/java-design-pattern [master] $ ./runContainer.sh
-6b2f81f18d5d
-6b2f81f18d5d
-delete container
-root@897bd347d0cd:/#

--- a/runContainer.sh
+++ b/runContainer.sh
@@ -1,0 +1,18 @@
+EXISTS=$(docker image ls | awk '{print $1}' | grep -E '^java$')
+if [ $EXISTS = "1" ]
+then
+  docker pull java
+fi
+
+# Containerがすでに存在すれば削除する
+CONTAINER_ID=$(docker container ls -a | grep java-design-pattern | awk '{print $1}')
+if [ -n "$CONTAINER_ID" ]
+then
+  docker stop $CONTAINER_ID
+  docker rm $CONTAINER_ID
+  echo "delete container"
+fi
+
+# javaイメージを使ってコンテナを実行
+docker  container run -v $(pwd):/home/share --name java-design-pattern -it java
+

--- a/runContainer.sh
+++ b/runContainer.sh
@@ -1,3 +1,4 @@
+#!/bin/bash
 EXISTS=$(docker image ls | awk '{print $1}' | grep -E '^java$')
 if [ $EXISTS = "1" ]
 then

--- a/runContainer.sh
+++ b/runContainer.sh
@@ -6,13 +6,13 @@ then
 fi
 
 # Containerがすでに存在すれば削除する
-CONTAINER_ID=$(docker container ls -a | grep java-design-pattern | awk '{print $1}')
-if [ -n "$CONTAINER_ID" ]
-then
-  docker stop $CONTAINER_ID
-  docker rm $CONTAINER_ID
-  echo "delete container"
-fi
+# CONTAINER_ID=$(docker container ls -a | grep java-design-pattern | awk '{print $1}')
+# if [ -n "$CONTAINER_ID" ]
+# then
+#   docker stop $CONTAINER_ID
+#   docker rm $CONTAINER_ID
+#   echo "delete container"
+# fi
 
 # javaイメージを使ってコンテナを実行
 docker  container run -v $(pwd):/home/share --name java-design-pattern -it java


### PR DESCRIPTION
# runContainer.shの要件
##  Must（対応済みのつもり）
- Javaを学習するのにDockerでいい感じにコンテナを立てて勉強したい
- シェルスクリプトを書いてみたかったので、docker-composeは使わない
- シェルスクリプトを実行するとそのほかのコマンドの実行をすることなく動かせる（image名の衝突、コンテナ名の衝突などが起こらない）

## Want（未対応、今後入れたい）
- shellがデフォルトなのでvimや.bashrcの設定をして便利にしたい
  - Dockerfileを用意しないといけない

## logs
runContainer.shの実行ログ
```
~/Desktop/java-design-pattern [master] $ ./runContainer.sh
6b2f81f18d5d
6b2f81f18d5d
delete container
root@897bd347d0cd:/#
```